### PR TITLE
hotfix: fix variable name conflict in feedback workflow

### DIFF
--- a/.github/workflows/genie-pr-feedback.yml
+++ b/.github/workflows/genie-pr-feedback.yml
@@ -90,7 +90,7 @@ jobs:
             });
             
             // Save context
-            const context = {
+            const prContext = {
               pr_number: pr.data.number,
               pr_title: pr.data.title,
               pr_body: pr.data.body || '',
@@ -107,7 +107,7 @@ jobs:
             
             // Write to file for Claude
             const fs = require('fs');
-            fs.writeFileSync('pr_context.json', JSON.stringify(context, null, 2));
+            fs.writeFileSync('pr_context.json', JSON.stringify(prContext, null, 2));
             
             // Output for next steps
             core.setOutput('pr_title', pr.data.title);


### PR DESCRIPTION
## 🚨 Critical Fix for Feedback Workflow

The @automagik-genie feedback workflow is failing due to a JavaScript variable name conflict.

### The Problem
- Variable named `context` conflicts with GitHub Actions' built-in `context` object
- Causes: `SyntaxError: Identifier 'context' has already been declared`
- Workflow fails immediately when triggered

### The Fix
- Renamed variable from `context` to `prContext`
- No functional changes, just avoiding the name collision

### Testing
Once merged, the @automagik-genie feedback system will work properly on PR #5.

Co-authored-by: Automagik Genie 🧞 <genie@namastex.ai>