### PR TITLE
fix: update payload structure for Evolution API and add fallback mech…

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -334,7 +334,7 @@ def custom_openapi():
         {
             "url": "http://localhost:8882",
             "description": "Local Development Server",
-        }
+        },
     ]
 
     # Update the existing HTTPBearer security scheme with better description

--- a/src/channels/whatsapp/evolution_api_sender.py
+++ b/src/channels/whatsapp/evolution_api_sender.py
@@ -283,9 +283,11 @@ class EvolutionApiSender:
                     if "textMessage" in error_message:
                         logger.warning("Trying fallback with old text format")
                         fallback_payload = {"number": formatted_recipient, "text": text}
-                        if mentioned: fallback_payload["mentioned"] = mentioned
-                        if mentions_everyone: fallback_payload["mentionsEveryOne"] = True
-                        
+                        if mentioned:
+                            fallback_payload["mentioned"] = mentioned
+                        if mentions_everyone:
+                            fallback_payload["mentionsEveryOne"] = True
+
                         fallback_response = requests.post(url, headers=headers, json=fallback_payload)
                         if fallback_response.status_code in [200, 201, 202]:
                             logger.info("Fallback succeeded")

--- a/src/channels/whatsapp/evolution_api_sender.py
+++ b/src/channels/whatsapp/evolution_api_sender.py
@@ -244,7 +244,7 @@ class EvolutionApiSender:
 
         headers = {"apikey": self.api_key, "Content-Type": "application/json"}
 
-        payload = {"number": formatted_recipient, "text": text}
+        payload = {"number": formatted_recipient, "textMessage": {"text": text}}
 
         # Add mention parameters
         if mentioned:
@@ -278,6 +278,18 @@ class EvolutionApiSender:
                     error_response = response.json()
                     error_message = str(error_response.get("message", ""))
                     logger.error(f"Evolution API 400 error response: {error_response}")
+
+                    # Try fallback with old text format if textMessage property error
+                    if "textMessage" in error_message:
+                        logger.warning("Trying fallback with old text format")
+                        fallback_payload = {"number": formatted_recipient, "text": text}
+                        if mentioned: fallback_payload["mentioned"] = mentioned
+                        if mentions_everyone: fallback_payload["mentionsEveryOne"] = True
+                        
+                        fallback_response = requests.post(url, headers=headers, json=fallback_payload)
+                        if fallback_response.status_code in [200, 201, 202]:
+                            logger.info("Fallback succeeded")
+                            return True
 
                     if quoted_message and ("typebotSessionId" in error_message or "database" in error_message.lower()):
                         logger.warning(f"Evolution API 400 error (known database schema issue): {error_message}")

--- a/tests/test_api_endpoints_e2e.py
+++ b/tests/test_api_endpoints_e2e.py
@@ -156,7 +156,7 @@ class TestHealthEndpoints(TestAPIEndpoints):
 
         # Verify bearer auth is configured
         assert "securitySchemes" in schema["components"]
-        assert "bearerAuth" in schema["components"]["securitySchemes"]
+        assert "HTTPBearer" in schema["components"]["securitySchemes"]
 
 
 class TestAuthenticationSecurity(TestAPIEndpoints):

--- a/tests/test_api_mentions.py
+++ b/tests/test_api_mentions.py
@@ -98,7 +98,7 @@ class TestApiMentions:
         # Check payload
         request_payload = call_args[1]["json"]
         assert request_payload["number"] == "5511777777777"
-        assert request_payload["text"] == payload["text"]
+        assert request_payload["textMessage"]["text"] == payload["text"]
 
         # Should have auto-parsed mentions in the payload
         assert "mentioned" in request_payload

--- a/tests/test_evolution_api_sender_mentions.py
+++ b/tests/test_evolution_api_sender_mentions.py
@@ -46,7 +46,7 @@ class TestEvolutionApiSenderMentions:
         payload = call_args[1]["json"]
 
         assert payload["number"] == recipient.replace("@g.us", "")
-        assert payload["text"] == text
+        assert payload["textMessage"]["text"] == text
         assert "mentioned" in payload
         assert len(payload["mentioned"]) == 2
         assert "5511999999999@s.whatsapp.net" in payload["mentioned"]
@@ -79,7 +79,7 @@ class TestEvolutionApiSenderMentions:
         payload = call_args[1]["json"]
 
         assert payload["number"] == recipient.replace("@g.us", "")
-        assert payload["text"] == text
+        assert payload["textMessage"]["text"] == text
         assert payload["mentioned"] == mentioned_jids
 
     @patch("src.channels.whatsapp.evolution_api_sender.requests.post")
@@ -100,7 +100,7 @@ class TestEvolutionApiSenderMentions:
         payload = call_args[1]["json"]
 
         assert payload["number"] == recipient.replace("@g.us", "")
-        assert payload["text"] == text
+        assert payload["textMessage"]["text"] == text
         assert payload["mentionsEveryOne"] is True
 
     @patch("src.channels.whatsapp.evolution_api_sender.requests.post")
@@ -121,7 +121,7 @@ class TestEvolutionApiSenderMentions:
         payload = call_args[1]["json"]
 
         assert payload["number"] == recipient.replace("@g.us", "")
-        assert payload["text"] == text
+        assert payload["textMessage"]["text"] == text
         assert "mentioned" not in payload
         assert "mentionsEveryOne" not in payload
 
@@ -174,13 +174,13 @@ class TestEvolutionApiSenderMentions:
         first_call_payload = mock_post.call_args_list[0][1]["json"]
         assert first_call_payload["mentioned"] == mentioned_jids
         assert first_call_payload["mentionsEveryOne"] is True
-        assert first_call_payload["text"] == "First part"
+        assert first_call_payload["textMessage"]["text"] == "First part"
 
         # Second message should not have mentions
         second_call_payload = mock_post.call_args_list[1][1]["json"]
         assert "mentioned" not in second_call_payload
         assert "mentionsEveryOne" not in second_call_payload
-        assert second_call_payload["text"] == "Second part"
+        assert second_call_payload["textMessage"]["text"] == "Second part"
 
     def test_send_text_message_missing_config(self, sender):
         """Test sending message without proper configuration."""

--- a/tests/test_mentions_integration.py
+++ b/tests/test_mentions_integration.py
@@ -101,7 +101,7 @@ class TestMentionsIntegration:
 
             # Verify payload structure
             assert request_payload["number"] == "5511777777777"
-            assert request_payload["text"] == payload["text"]
+            assert request_payload["textMessage"]["text"] == payload["text"]
 
             # Verify mentions were parsed correctly
             assert "mentioned" in request_payload
@@ -191,7 +191,7 @@ class TestMentionsIntegration:
             request_payload = call_args[1]["json"]
 
             assert request_payload["mentionsEveryOne"] is True
-            assert request_payload["text"] == payload["text"]
+            assert request_payload["textMessage"]["text"] == payload["text"]
 
     def test_mention_flow_with_split_messages(self, client, test_instance_config, api_headers):
         """Test mention flow when message gets split."""
@@ -231,13 +231,13 @@ class TestMentionsIntegration:
             first_payload = first_call[1]["json"]
             assert "mentioned" in first_payload
             assert "5511999999999@s.whatsapp.net" in first_payload["mentioned"]
-            assert first_payload["text"] == "First part with @5511999999999"
+            assert first_payload["textMessage"]["text"] == "First part with @5511999999999"
 
             # Second message should not have mentions
             second_call = mock_http_post.call_args_list[1]
             second_payload = second_call[1]["json"]
             assert "mentioned" not in second_payload
-            assert second_payload["text"] == "Second part without mentions"
+            assert second_payload["textMessage"]["text"] == "Second part without mentions"
 
     def test_mention_flow_error_handling(self, client, test_instance_config, api_headers):
         """Test mention flow with various error conditions."""


### PR DESCRIPTION
**Fix Evolution API v2 `textMessage` requirement**

**Summary**
Fixes critical WhatsApp messaging issues caused by Evolution API v2 payload changes.

**Issues Fixed**

* Evolution API 400 error: *"instance requires property `textMessage`"*

**Changes**

* Updated payload structure from `{"text": text}` → `{"textMessage": {"text": text}}`
* Added fallback to legacy format if v2 format fails
* Updated test assertions to align with new payload structure

**Impact**

* Restores WhatsApp messaging for Evolution API v2 users
* Preserves backward compatibility with v1
