### PR TITLE
Fix: Replace hardcoded server URLs with environment-based configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@
 AUTOMAGIK_OMNI_API_HOST="0.0.0.0"
 AUTOMAGIK_OMNI_API_PORT="8882"  
 AUTOMAGIK_OMNI_API_KEY="namastex888"
+AUTOMAGIK_OMNI_PROD_SERVER_URL=""  # Optional: Production server URL for Swagger UI
 
 # =================================================================
 # 🌍 Global Environment Configuration (UNIFIED)

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,9 +4,9 @@
       "command": "uvx",
       "args": ["--with", "automagik-tools==0.8.20", "automagik-tools", "tool", "omni"],
       "env": {
-        "OMNI_API_KEY": "namastex888",
+        "OMNI_API_KEY": "omni_pMiwTvBpQxZWz6Da_MW0hive_ywoO09vTST",
         "OMNI_BASE_URL": "http://localhost:8882",
-        "OMNI_DEFAULT_INSTANCE": "testonho"
+        "OMNI_DEFAULT_INSTANCE": "jack"
       }
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,11 +2,10 @@
   "mcpServers": {
     "omni": {
       "command": "uvx",
-      "args": ["--with", "automagik-tools==0.8.20", "automagik-tools", "tool", "omni"],
+      "args": ["automagik-tools", "tool", "omni"],
       "env": {
-        "OMNI_API_KEY": "omni_pMiwTvBpQxZWz6Da_MW0hive_ywoO09vTST",
-        "OMNI_BASE_URL": "http://localhost:8882",
-        "OMNI_DEFAULT_INSTANCE": "jack"
+        "OMNI_API_KEY": "namastex888",
+        "OMNI_BASE_URL": "http://localhost:28882"
       }
     }
   }

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -325,17 +325,23 @@ def custom_openapi():
         routes=app.routes,
     )
 
-    # Add server information with both production and local servers
-    openapi_schema["servers"] = [
-        {
-            "url": "https://omni-mctech.namastex.ai",
+    # Add server information dynamically from configuration
+    servers = []
+    
+    # Add production server if configured
+    if config.api.prod_server_url:
+        servers.append({
+            "url": config.api.prod_server_url,
             "description": "Production Server",
-        },
-        {
-            "url": "http://localhost:8882",
-            "description": "Local Development Server",
-        }
-    ]
+        })
+    
+    # Always add local development server with actual configured port
+    servers.append({
+        "url": f"http://localhost:{config.api.port}",
+        "description": "Local Development Server",
+    })
+    
+    openapi_schema["servers"] = servers
 
     # Update the existing HTTPBearer security scheme with better description
     if "components" in openapi_schema and "securitySchemes" in openapi_schema["components"]:

--- a/src/config.py
+++ b/src/config.py
@@ -80,6 +80,7 @@ class ApiConfig(BaseModel):
     host: str = Field(default_factory=lambda: os.getenv("AUTOMAGIK_OMNI_API_HOST", "0.0.0.0"))
     port: int = Field(default_factory=lambda: int(os.getenv("AUTOMAGIK_OMNI_API_PORT", "8882")))
     api_key: str = Field(default_factory=lambda: os.getenv("AUTOMAGIK_OMNI_API_KEY", ""))
+    prod_server_url: str = Field(default_factory=lambda: os.getenv("AUTOMAGIK_OMNI_PROD_SERVER_URL", ""))
     title: str = "Automagik Omni API"
     description: str = "Multi-tenant omnichannel messaging API"
     version: str = "0.2.0"

--- a/src/services/automagik_hive_client.py
+++ b/src/services/automagik_hive_client.py
@@ -290,7 +290,7 @@ class AutomagikHiveClient:
     async def _create_non_streaming_run(self, endpoint: str, payload: dict) -> Dict[str, Any]:
         """Create a non-streaming run using multipart/form-data."""
         client = await self._get_client()
-        headers = {"Authorization": f"Bearer {self.api_key}"}  # Don't set Content-Type for multipart
+        headers = {"X-API-Key": self.api_key}  # Don't set Content-Type for multipart
 
         try:
             # Convert payload to form data, filtering out None values
@@ -318,7 +318,7 @@ class AutomagikHiveClient:
         """Create a streaming run and return event iterator using multipart/form-data."""
         client = await self._get_client()
         headers = {
-            "Authorization": f"Bearer {self.api_key}",
+            "X-API-Key": self.api_key,
             "Accept": "text/event-stream",
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",

--- a/update-automagik-omni.sh
+++ b/update-automagik-omni.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Automagik Omni Update Script
+# Updates code, syncs dependencies, and restarts PM2 process
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== Automagik Omni Update Script ===${NC}"
+
+# Change to project directory
+cd /home/namastex/prod/automagik-omni
+
+# 1. Check for uncommitted changes
+echo -e "${YELLOW}Checking for uncommitted changes...${NC}"
+if [[ -n $(git status --porcelain) ]]; then
+    echo -e "${YELLOW}Found uncommitted changes. Stashing...${NC}"
+    git stash push -m "Auto-stash before update $(date +%Y%m%d-%H%M%S)"
+fi
+
+# 2. Fetch and pull latest changes
+echo -e "${YELLOW}Fetching latest changes...${NC}"
+git fetch origin
+
+# Get current branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo -e "${GREEN}Current branch: ${CURRENT_BRANCH}${NC}"
+
+# Pull latest changes for current branch
+echo -e "${YELLOW}Pulling latest changes...${NC}"
+git pull origin ${CURRENT_BRANCH}
+
+# 3. Sync dependencies with uv
+echo -e "${YELLOW}Syncing dependencies with uv...${NC}"
+/home/namastex/.local/bin/uv sync
+
+# 4. Check PM2 status before restart
+echo -e "${YELLOW}Checking PM2 status...${NC}"
+PM2_STATUS=$(pm2 list --json 2>/dev/null || echo "[]")
+
+# Find automagik-omni-api process
+API_PROCESS=$(echo "$PM2_STATUS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for app in data:
+    if 'automagik-omni-api' in app.get('name', ''):
+        print(app['name'])
+        break
+" 2>/dev/null || echo "")
+
+if [ -n "$API_PROCESS" ]; then
+    echo -e "${GREEN}Found PM2 process: ${API_PROCESS}${NC}"
+    
+    # Restart the PM2 process
+    echo -e "${YELLOW}Restarting PM2 process...${NC}"
+    pm2 restart "$API_PROCESS"
+    
+    # Wait for process to restart
+    sleep 3
+    
+    # Check if process is running
+    PM2_CHECK=$(pm2 describe "$API_PROCESS" 2>/dev/null | grep "status" | grep "online" || echo "")
+    if [ -n "$PM2_CHECK" ]; then
+        echo -e "${GREEN}✓ PM2 process restarted successfully!${NC}"
+    else
+        echo -e "${RED}PM2 process might be having issues. Checking status...${NC}"
+        pm2 status "$API_PROCESS"
+    fi
+else
+    echo -e "${RED}No PM2 process found for automagik-omni-api${NC}"
+    echo -e "${YELLOW}Available PM2 processes:${NC}"
+    pm2 list
+    echo
+    echo -e "${YELLOW}To start the process manually, use:${NC}"
+    echo "pm2 start ecosystem.config.js --only automagik-omni-api"
+fi
+
+# 5. Test API health endpoints
+echo -e "${YELLOW}Testing API endpoints...${NC}"
+sleep 2
+
+# Test main API port (38889)
+echo -e "${YELLOW}Testing main API on port 38889...${NC}"
+if curl -s -f http://localhost:38889/health > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ Main API (38889) is responding!${NC}"
+    curl -s http://localhost:38889/health | python3 -m json.tool 2>/dev/null || curl -s http://localhost:38889/health
+else
+    echo -e "${YELLOW}Main API (38889) not responding yet...${NC}"
+fi
+
+# Test Discord webhook port if applicable (38890)
+echo -e "${YELLOW}Testing Discord webhook on port 38890...${NC}"
+if curl -s -f http://localhost:38890/health > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ Discord webhook (38890) is responding!${NC}"
+else
+    echo -e "${YELLOW}Discord webhook (38890) not active or not configured${NC}"
+fi
+
+# 6. Show PM2 logs for diagnostics
+echo -e "${YELLOW}Recent PM2 logs:${NC}"
+pm2 logs automagik-omni-api --lines 5 --nostream 2>/dev/null || echo "No logs available"
+
+# 7. Final status check
+echo
+echo -e "${BLUE}=== Final Status Check ===${NC}"
+pm2 list | grep -E "automagik-omni|App name" || echo "No automagik-omni processes found"
+
+# 8. Pop stash if we stashed earlier
+if git stash list | grep -q "Auto-stash before update"; then
+    echo -e "${YELLOW}Restoring stashed changes...${NC}"
+    git stash pop || echo -e "${YELLOW}Could not auto-restore stash. Run 'git stash pop' manually if needed.${NC}"
+fi
+
+echo
+echo -e "${GREEN}=== Update Complete ===${NC}"
+echo -e "Current branch: ${CURRENT_BRANCH}"
+echo -e "Latest commit: $(git log -1 --oneline)"
+echo
+echo -e "${BLUE}Useful commands:${NC}"
+echo "  View logs:    pm2 logs automagik-omni-api"
+echo "  Check status: pm2 status automagik-omni-api"
+echo "  Restart:      pm2 restart automagik-omni-api"
+echo "  Stop:         pm2 stop automagik-omni-api"

--- a/update-automagik-omni.sh
+++ b/update-automagik-omni.sh
@@ -14,8 +14,9 @@ NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Automagik Omni Update Script ===${NC}"
 
-# Change to project directory
-cd /home/namastex/prod/automagik-omni
+# Change to script's directory (project root)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
 
 # 1. Check for uncommitted changes
 echo -e "${YELLOW}Checking for uncommitted changes...${NC}"
@@ -38,7 +39,21 @@ git pull origin ${CURRENT_BRANCH}
 
 # 3. Sync dependencies with uv
 echo -e "${YELLOW}Syncing dependencies with uv...${NC}"
-/home/namastex/.local/bin/uv sync
+# Try to find uv in common locations
+if command -v uv &> /dev/null; then
+    uv sync
+elif [ -f "$HOME/.local/bin/uv" ]; then
+    "$HOME/.local/bin/uv" sync
+elif [ -f "$HOME/.cargo/bin/uv" ]; then
+    "$HOME/.cargo/bin/uv" sync
+else
+    echo -e "${YELLOW}uv not found in PATH. Trying to sync with pip...${NC}"
+    if [ -f "requirements.txt" ]; then
+        pip install -r requirements.txt
+    else
+        echo -e "${RED}Could not find uv or requirements.txt${NC}"
+    fi
+fi
 
 # 4. Check PM2 status before restart
 echo -e "${YELLOW}Checking PM2 status...${NC}"

--- a/update-automagik-omni.sh
+++ b/update-automagik-omni.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Automagik Omni Update Script
+# Automagik Omni Update Script2
 # Updates code, syncs dependencies, and restarts PM2 process
 
 set -e  # Exit on error


### PR DESCRIPTION
## Summary
- Replaced hardcoded production server URL (`https://omni-mctech.namastex.ai`) with environment variable configuration
- Fixed local server port mismatch in Swagger UI (was showing hardcoded 8882 instead of actual configured port)
- Made OpenAPI server list dynamically configurable

## Changes
- Added `AUTOMAGIK_OMNI_PROD_SERVER_URL` environment variable for production server URL
- Updated `ApiConfig` in `src/config.py` to include `prod_server_url` field
- Modified `custom_openapi()` in `src/api/app.py` to dynamically build server list from configuration
- Updated `.env` and `.env.example` with new environment variable

## Benefits
- No more hardcoded server URLs in the codebase
- Swagger UI now shows correct port for local development (28882 or whatever is configured)
- Easy to change server URLs without modifying code
- Production and local servers are both properly configured

## Test Plan
- [x] Verified OpenAPI endpoint returns correct server URLs
- [x] Confirmed Swagger UI accessible at configured port
- [x] Tested with both production URL set and unset