### PR TITLE
feat: auto-close issues linked in PR body on merge

### DIFF
--- a/.github/workflows/auto-close-linked-issues.yml
+++ b/.github/workflows/auto-close-linked-issues.yml
@@ -1,0 +1,126 @@
+name: Auto-Close Linked Issues on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  auto-close-issues:
+    runs-on: ubuntu-latest
+    # Only run if PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Extract issue numbers from PR body
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body || '';
+            const prNumber = context.payload.pull_request.number;
+
+            console.log('PR #' + prNumber + ' was merged');
+            console.log('Scanning PR body for closing keywords...');
+
+            // Match patterns: "Closes #123", "Fixes #456", "Resolves #789"
+            // Case-insensitive, supports various formats
+            const closePattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+
+            const matches = [...prBody.matchAll(closePattern)];
+            const issueNumbers = matches.map(match => match[1]);
+
+            // Remove duplicates
+            const uniqueIssues = [...new Set(issueNumbers)];
+
+            if (uniqueIssues.length === 0) {
+              console.log('No issues to close (no closing keywords found in PR body)');
+              core.setOutput('has_issues', 'false');
+              return;
+            }
+
+            console.log('Found ' + uniqueIssues.length + ' issue(s) to close:', uniqueIssues.join(', '));
+            core.setOutput('has_issues', 'true');
+            core.setOutput('issue_numbers', JSON.stringify(uniqueIssues));
+
+      - name: Close linked issues
+        if: steps.extract.outputs.has_issues == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumbers = JSON.parse('${{ steps.extract.outputs.issue_numbers }}');
+            const prNumber = context.payload.pull_request.number;
+            const prTitle = context.payload.pull_request.title;
+            const prUrl = context.payload.pull_request.html_url;
+            const prAuthor = context.payload.pull_request.user.login;
+
+            console.log('Closing ' + issueNumbers.length + ' linked issue(s)...');
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                // Check if issue exists and is open
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: parseInt(issueNumber)
+                });
+
+                if (issue.state === 'closed') {
+                  console.log('Issue #' + issueNumber + ' is already closed, skipping');
+                  continue;
+                }
+
+                // Add comment explaining the closure
+                const comment = `✅ **Automatically closed via PR #${prNumber}**\n\n` +
+                  `**PR Title:** ${prTitle}\n` +
+                  `**Merged by:** @${prAuthor}\n` +
+                  `**PR Link:** ${prUrl}\n\n` +
+                  `This issue was automatically closed because the merged PR contained closing keywords in its description.`;
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: parseInt(issueNumber),
+                  body: comment
+                });
+
+                // Close the issue
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: parseInt(issueNumber),
+                  state: 'closed'
+                });
+
+                console.log('✓ Closed issue #' + issueNumber + ': ' + issue.title);
+
+              } catch (error) {
+                console.error('Failed to close issue #' + issueNumber + ':', error.message);
+                // Continue with other issues even if one fails
+              }
+            }
+
+            console.log('Issue closure process complete');
+
+      - name: Comment on PR with closure summary
+        if: steps.extract.outputs.has_issues == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumbers = JSON.parse('${{ steps.extract.outputs.issue_numbers }}');
+
+            const issueLinks = issueNumbers.map(num => `#${num}`).join(', ');
+
+            const comment = `🤖 **Auto-Close Report**\n\n` +
+              `Automatically closed ${issueNumbers.length} linked issue(s): ${issueLinks}\n\n` +
+              `Issues were closed because this PR's description contained closing keywords ` +
+              `(\`Closes\`, \`Fixes\`, or \`Resolves\`) followed by issue numbers.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: comment
+            });


### PR DESCRIPTION
## Summary

Automatically closes issues referenced in PR descriptions when the PR is merged, fixing the issue where closing keywords in PR body don't trigger GitHub's native auto-close.

## Problem

When PRs contain `Closes #X` in the **description** but not in commit messages, GitHub doesn't auto-close the linked issues on merge. This requires manual issue closure, which is error-prone.

**Example:** PR #49 had `Closes #35` and `Closes #36` in description, but issues stayed open after merge.

## Solution

Created a GitHub Action workflow that:
- Triggers on PR merge events
- Extracts issue numbers from closing keywords (`Closes`, `Fixes`, `Resolves`)
- Automatically closes each linked issue via GitHub API
- Adds explanatory comments to closed issues and PR

## Testing

To test this workflow:
1. Reopened issues #35 and #36 (which were linked in PR #49)
2. This PR will merge with those same closing keywords
3. Workflow should auto-close both issues on merge

## Changes

- Added `.github/workflows/auto-close-linked-issues.yml`
- Workflow uses `actions/github-script` for issue management
- Only runs on merged PRs (not just closed)
- Supports all closing keyword variants (case-insensitive)

## Related

- Closes #35 - Integrate wish system enhancements to omni
- Closes #36 - Review and normalize old wishes in omni

(These are intentionally reopened test issues to validate the workflow)