### PR TITLE
fix: use bunx pm2 for cross-platform compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ install: ## Install dependencies and deploy to PM2
 	@echo "$(FONT_CYAN)Building UI...$(FONT_RESET)"
 	cd resources/ui && bun run build
 	@echo "$(FONT_CYAN)Starting PM2 service...$(FONT_RESET)"
-	bunx pm2 start ecosystem.config.cjs 2>/dev/null || bunx pm2 restart ecosystem.config.cjs
+	bunx pm2 startOrRestart ecosystem.config.cjs
 	bunx pm2 save
 	@echo ""
 	@echo "$(FONT_GREEN)Done!$(FONT_RESET) Access at http://localhost:8882"
@@ -87,7 +87,7 @@ update: ## Pull updates, rebuild everything, restart
 	@echo "$(FONT_CYAN)Rebuilding UI...$(FONT_RESET)"
 	@cd resources/ui && bun install && bun run build
 	@echo "$(FONT_CYAN)Restarting services...$(FONT_RESET)"
-	@bunx pm2 restart ecosystem.config.cjs 2>/dev/null || bunx pm2 start ecosystem.config.cjs
+	@bunx pm2 startOrRestart ecosystem.config.cjs
 	@bunx pm2 save
 	@echo ""
 	@echo "$(FONT_GREEN)Update complete!$(FONT_RESET)"

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ install: ## Install dependencies and deploy to PM2
 	@echo "$(FONT_CYAN)Building UI...$(FONT_RESET)"
 	cd resources/ui && bun run build
 	@echo "$(FONT_CYAN)Starting PM2 service...$(FONT_RESET)"
-	pm2 start ecosystem.config.cjs 2>/dev/null || pm2 restart ecosystem.config.cjs
-	pm2 save
+	bunx pm2 start ecosystem.config.cjs 2>/dev/null || bunx pm2 restart ecosystem.config.cjs
+	bunx pm2 save
 	@echo ""
 	@echo "$(FONT_GREEN)Done!$(FONT_RESET) Access at http://localhost:8882"
 
@@ -60,7 +60,7 @@ reload: ## Restart services (after code changes)
 	@echo "$(FONT_CYAN)Rebuilding UI...$(FONT_RESET)"
 	@cd resources/ui && bun run build
 	@echo "$(FONT_CYAN)Restarting PM2 service...$(FONT_RESET)"
-	@pm2 restart ecosystem.config.cjs
+	@bunx pm2 restart ecosystem.config.cjs
 	@echo ""
 	@echo "$(FONT_GREEN)Reload complete!$(FONT_RESET)"
 
@@ -87,15 +87,15 @@ update: ## Pull updates, rebuild everything, restart
 	@echo "$(FONT_CYAN)Rebuilding UI...$(FONT_RESET)"
 	@cd resources/ui && bun install && bun run build
 	@echo "$(FONT_CYAN)Restarting services...$(FONT_RESET)"
-	@pm2 restart ecosystem.config.cjs 2>/dev/null || pm2 start ecosystem.config.cjs
-	@pm2 save
+	@bunx pm2 restart ecosystem.config.cjs 2>/dev/null || bunx pm2 start ecosystem.config.cjs
+	@bunx pm2 save
 	@echo ""
 	@echo "$(FONT_GREEN)Update complete!$(FONT_RESET)"
 
 uninstall: ## Stop services and cleanup (prompts for data wipe)
 	@echo ""
 	@echo "$(FONT_YELLOW)Stopping PM2 services...$(FONT_RESET)"
-	@pm2 delete ecosystem.config.cjs 2>/dev/null || true
+	@bunx pm2 delete ecosystem.config.cjs 2>/dev/null || true
 	@echo "$(FONT_YELLOW)Removing dependencies...$(FONT_RESET)"
 	@rm -rf .venv node_modules gateway/node_modules resources/ui/node_modules resources/omni-whatsapp-core/node_modules
 	@rm -rf gateway/dist resources/ui/dist dist build *.egg-info


### PR DESCRIPTION
## Summary
- Replace direct `pm2` calls with `bunx pm2` in Makefile
- Ensures `make install` works on any OS without requiring global pm2 installation

## Motivation
When running `make install` on a fresh system, the command fails with:
```
/bin/bash: pm2: command not found
make: *** [install] Error 127
```

This happens because pm2 is called directly but isn't installed globally. Using `bunx pm2` solves this by automatically downloading and running pm2 through bun's package runner, similar to how `npx` works for npm.

## Test plan
- [x] Tested `make install` on macOS - works successfully