### PR TITLE
fix: TTS reads ElevenLabs credentials from GlobalSetting

### DIFF
--- a/resources/ui/src/components/settings/MediaProcessingSettings.tsx
+++ b/resources/ui/src/components/settings/MediaProcessingSettings.tsx
@@ -10,16 +10,17 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { api } from '@/lib';
 import { Eye, EyeOff, Save, Loader2, CheckCircle2, XCircle, Image, Mic, Sparkles, Volume2, AudioLines } from 'lucide-react';
 
-interface ApiKeyFieldProps {
+interface SettingFieldProps {
   label: string;
   description: string;
   settingKey: string;
   currentValue: string | null;
   icon: React.ReactNode;
   placeholder?: string;
+  isSecret?: boolean;
 }
 
-function ApiKeyField({ label, description, settingKey, currentValue, icon, placeholder }: ApiKeyFieldProps) {
+function SettingField({ label, description, settingKey, currentValue, icon, placeholder, isSecret = false }: SettingFieldProps) {
   const queryClient = useQueryClient();
   const [value, setValue] = useState('');
   const [showValue, setShowValue] = useState(false);
@@ -51,7 +52,9 @@ function ApiKeyField({ label, description, settingKey, currentValue, icon, place
     setValue('');
   };
 
-  const maskedValue = currentValue ? `${currentValue.substring(0, 8)}...${currentValue.slice(-4)}` : null;
+  const displayValue = isSecret && currentValue
+    ? `${currentValue.substring(0, 8)}...${currentValue.slice(-4)}`
+    : currentValue;
 
   return (
     <div className="p-4 bg-muted rounded-lg border border-border space-y-3">
@@ -79,24 +82,34 @@ function ApiKeyField({ label, description, settingKey, currentValue, icon, place
       {isEditing ? (
         <div className="space-y-2">
           <div className="flex gap-2">
-            <div className="relative flex-1">
+            {isSecret ? (
+              <div className="relative flex-1">
+                <Input
+                  type={showValue ? 'text' : 'password'}
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  placeholder={placeholder || `Enter ${label}`}
+                  className="pr-10"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7"
+                  onClick={() => setShowValue(!showValue)}
+                >
+                  {showValue ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </Button>
+              </div>
+            ) : (
               <Input
-                type={showValue ? 'text' : 'password'}
+                type="text"
                 value={value}
                 onChange={(e) => setValue(e.target.value)}
                 placeholder={placeholder || `Enter ${label}`}
-                className="pr-10"
+                className="flex-1"
               />
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7"
-                onClick={() => setShowValue(!showValue)}
-              >
-                {showValue ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-              </Button>
-            </div>
+            )}
             <Button onClick={handleSave} disabled={updateMutation.isPending} size="sm">
               {updateMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
             </Button>
@@ -108,102 +121,7 @@ function ApiKeyField({ label, description, settingKey, currentValue, icon, place
       ) : (
         <div className="flex items-center justify-between">
           <code className="text-sm text-muted-foreground font-mono">
-            {maskedValue || <span className="italic">Not configured</span>}
-          </code>
-          <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
-            {currentValue ? 'Update' : 'Configure'}
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-interface SettingTextFieldProps {
-  label: string;
-  description: string;
-  settingKey: string;
-  currentValue: string | null;
-  icon: React.ReactNode;
-  placeholder?: string;
-}
-
-function SettingTextField({ label, description, settingKey, currentValue, icon, placeholder }: SettingTextFieldProps) {
-  const queryClient = useQueryClient();
-  const [value, setValue] = useState('');
-  const [isEditing, setIsEditing] = useState(false);
-
-  const updateMutation = useMutation({
-    mutationFn: (newValue: string) => api.settings.update(settingKey, { value: newValue }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings'] });
-      toast.success(`${label} updated successfully`);
-      setIsEditing(false);
-      setValue('');
-    },
-    onError: (err: Error) => {
-      toast.error(`Failed to update ${label}: ${err.message}`);
-    },
-  });
-
-  const handleSave = () => {
-    if (!value.trim()) {
-      toast.error('Please enter a value');
-      return;
-    }
-    updateMutation.mutate(value);
-  };
-
-  const handleCancel = () => {
-    setIsEditing(false);
-    setValue('');
-  };
-
-  return (
-    <div className="p-4 bg-muted rounded-lg border border-border space-y-3">
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-2">
-          {icon}
-          <div>
-            <Label className="text-sm font-medium">{label}</Label>
-            <p className="text-xs text-muted-foreground">{description}</p>
-          </div>
-        </div>
-        {currentValue ? (
-          <Badge variant="default" className="bg-green-500/10 text-green-600 border-green-500/20">
-            <CheckCircle2 className="h-3 w-3 mr-1" />
-            Configured
-          </Badge>
-        ) : (
-          <Badge variant="outline" className="text-muted-foreground">
-            <XCircle className="h-3 w-3 mr-1" />
-            Not Set
-          </Badge>
-        )}
-      </div>
-
-      {isEditing ? (
-        <div className="space-y-2">
-          <div className="flex gap-2">
-            <Input
-              type="text"
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              placeholder={placeholder || `Enter ${label}`}
-              className="flex-1"
-            />
-            <Button onClick={handleSave} disabled={updateMutation.isPending} size="sm">
-              {updateMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-            </Button>
-            <Button variant="outline" onClick={handleCancel} size="sm">
-              Cancel
-            </Button>
-          </div>
-        </div>
-      ) : (
-        <div className="flex items-center justify-between">
-          <code className="text-sm text-muted-foreground font-mono">
-            {currentValue || <span className="italic">Not configured</span>}
+            {displayValue || <span className="italic">Not configured</span>}
           </code>
           <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
             {currentValue ? 'Update' : 'Configure'}
@@ -254,22 +172,24 @@ export function MediaProcessingSettings() {
           <CardDescription>Configure API keys for image description and video analysis</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <ApiKeyField
+          <SettingField
             label="Google Gemini API Key"
             description="Primary provider for image/video description (gemini-2.5-flash)"
             settingKey="gemini_api_key"
             currentValue={getSetting('gemini_api_key')}
             icon={<Sparkles className="h-4 w-4 text-blue-500" />}
             placeholder="AIza..."
+            isSecret
           />
 
-          <ApiKeyField
+          <SettingField
             label="OpenAI API Key"
             description="Fallback for images when Gemini is unavailable (gpt-5-nano)"
             settingKey="openai_api_key"
             currentValue={getSetting('openai_api_key')}
             icon={<Sparkles className="h-4 w-4 text-green-500" />}
             placeholder="sk-..."
+            isSecret
           />
         </CardContent>
       </Card>
@@ -284,13 +204,14 @@ export function MediaProcessingSettings() {
           <CardDescription>Configure API keys for audio transcription services</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <ApiKeyField
+          <SettingField
             label="Groq API Key"
             description="Primary provider for audio transcription (whisper-large-v3-turbo, 216x real-time)"
             settingKey="groq_api_key"
             currentValue={getSetting('groq_api_key')}
             icon={<Mic className="h-4 w-4 text-orange-500" />}
             placeholder="gsk_..."
+            isSecret
           />
 
           <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg">
@@ -312,16 +233,17 @@ export function MediaProcessingSettings() {
           <CardDescription>Configure API keys for text-to-speech and audio generation</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <ApiKeyField
+          <SettingField
             label="ElevenLabs API Key"
             description="Text-to-speech voice message generation for WhatsApp"
             settingKey="XI_API_KEY"
             currentValue={getSetting('XI_API_KEY')}
             icon={<Volume2 className="h-4 w-4 text-purple-500" />}
             placeholder="sk_..."
+            isSecret
           />
 
-          <SettingTextField
+          <SettingField
             label="ElevenLabs Voice ID"
             description="Default voice for TTS generation (can be overridden per request)"
             settingKey="XI_VOICE_ID"

--- a/resources/ui/src/components/settings/MediaProcessingSettings.tsx
+++ b/resources/ui/src/components/settings/MediaProcessingSettings.tsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { api } from '@/lib';
-import { Eye, EyeOff, Save, Loader2, CheckCircle2, XCircle, Image, Mic, Sparkles, Volume2 } from 'lucide-react';
+import { Eye, EyeOff, Save, Loader2, CheckCircle2, XCircle, Image, Mic, Sparkles, Volume2, AudioLines } from 'lucide-react';
 
 interface ApiKeyFieldProps {
   label: string;
@@ -109,6 +109,101 @@ function ApiKeyField({ label, description, settingKey, currentValue, icon, place
         <div className="flex items-center justify-between">
           <code className="text-sm text-muted-foreground font-mono">
             {maskedValue || <span className="italic">Not configured</span>}
+          </code>
+          <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
+            {currentValue ? 'Update' : 'Configure'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SettingTextFieldProps {
+  label: string;
+  description: string;
+  settingKey: string;
+  currentValue: string | null;
+  icon: React.ReactNode;
+  placeholder?: string;
+}
+
+function SettingTextField({ label, description, settingKey, currentValue, icon, placeholder }: SettingTextFieldProps) {
+  const queryClient = useQueryClient();
+  const [value, setValue] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
+
+  const updateMutation = useMutation({
+    mutationFn: (newValue: string) => api.settings.update(settingKey, { value: newValue }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success(`${label} updated successfully`);
+      setIsEditing(false);
+      setValue('');
+    },
+    onError: (err: Error) => {
+      toast.error(`Failed to update ${label}: ${err.message}`);
+    },
+  });
+
+  const handleSave = () => {
+    if (!value.trim()) {
+      toast.error('Please enter a value');
+      return;
+    }
+    updateMutation.mutate(value);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setValue('');
+  };
+
+  return (
+    <div className="p-4 bg-muted rounded-lg border border-border space-y-3">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          {icon}
+          <div>
+            <Label className="text-sm font-medium">{label}</Label>
+            <p className="text-xs text-muted-foreground">{description}</p>
+          </div>
+        </div>
+        {currentValue ? (
+          <Badge variant="default" className="bg-green-500/10 text-green-600 border-green-500/20">
+            <CheckCircle2 className="h-3 w-3 mr-1" />
+            Configured
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="text-muted-foreground">
+            <XCircle className="h-3 w-3 mr-1" />
+            Not Set
+          </Badge>
+        )}
+      </div>
+
+      {isEditing ? (
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <Input
+              type="text"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={placeholder || `Enter ${label}`}
+              className="flex-1"
+            />
+            <Button onClick={handleSave} disabled={updateMutation.isPending} size="sm">
+              {updateMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            </Button>
+            <Button variant="outline" onClick={handleCancel} size="sm">
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between">
+          <code className="text-sm text-muted-foreground font-mono">
+            {currentValue || <span className="italic">Not configured</span>}
           </code>
           <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
             {currentValue ? 'Update' : 'Configure'}
@@ -224,6 +319,15 @@ export function MediaProcessingSettings() {
             currentValue={getSetting('XI_API_KEY')}
             icon={<Volume2 className="h-4 w-4 text-purple-500" />}
             placeholder="sk_..."
+          />
+
+          <SettingTextField
+            label="ElevenLabs Voice ID"
+            description="Default voice for TTS generation (can be overridden per request)"
+            settingKey="XI_VOICE_ID"
+            currentValue={getSetting('XI_VOICE_ID')}
+            icon={<AudioLines className="h-4 w-4 text-purple-500" />}
+            placeholder="JBFqnCBsd6RMkjVDRZzb"
           />
         </CardContent>
       </Card>

--- a/src/services/settings_service.py
+++ b/src/services/settings_service.py
@@ -438,3 +438,53 @@ def get_evolution_api_key_global() -> str:
         Unified API key string
     """
     return get_omni_api_key_global()
+
+
+def get_elevenlabs_api_key_global() -> str:
+    """
+    Get ElevenLabs API key from database with .env fallback.
+
+    The Settings UI saves this as 'XI_API_KEY' in the GlobalSetting table.
+
+    Returns:
+        ElevenLabs API key string, or empty string if not configured.
+    """
+    from src.db.database import SessionLocal
+    from src.config import config
+
+    # Try database first (primary source - set via Settings UI)
+    try:
+        with SessionLocal() as db:
+            key = settings_service.get_setting_value("XI_API_KEY", db, default=None)
+            if key:
+                return key
+    except Exception as e:
+        logger.warning(f"Failed to get ElevenLabs API key from database: {e}")
+
+    # Fallback to .env
+    return config.get_env("XI_API_KEY", "")
+
+
+def get_elevenlabs_voice_id_global() -> str:
+    """
+    Get ElevenLabs default voice ID from database with .env fallback.
+
+    The Settings UI saves this as 'XI_VOICE_ID' in the GlobalSetting table.
+
+    Returns:
+        ElevenLabs voice ID string, or empty string if not configured.
+    """
+    from src.db.database import SessionLocal
+    from src.config import config
+
+    # Try database first (primary source - set via Settings UI)
+    try:
+        with SessionLocal() as db:
+            voice_id = settings_service.get_setting_value("XI_VOICE_ID", db, default=None)
+            if voice_id:
+                return voice_id
+    except Exception as e:
+        logger.warning(f"Failed to get ElevenLabs voice ID from database: {e}")
+
+    # Fallback to .env
+    return config.get_env("XI_VOICE_ID", "")

--- a/src/services/settings_service.py
+++ b/src/services/settings_service.py
@@ -440,51 +440,36 @@ def get_evolution_api_key_global() -> str:
     return get_omni_api_key_global()
 
 
-def get_elevenlabs_api_key_global() -> str:
-    """
-    Get ElevenLabs API key from database with .env fallback.
+def _get_global_setting(db_key: str, env_key: str, env_default: str = "") -> str:
+    """Get a setting from database with .env fallback.
 
-    The Settings UI saves this as 'XI_API_KEY' in the GlobalSetting table.
+    Args:
+        db_key: Key to look up in GlobalSetting table.
+        env_key: Environment variable name for fallback.
+        env_default: Default value if neither DB nor env is set.
 
     Returns:
-        ElevenLabs API key string, or empty string if not configured.
+        Setting value string, or env_default if not configured.
     """
     from src.db.database import SessionLocal
     from src.config import config
 
-    # Try database first (primary source - set via Settings UI)
     try:
         with SessionLocal() as db:
-            key = settings_service.get_setting_value("XI_API_KEY", db, default=None)
-            if key:
-                return key
+            value = settings_service.get_setting_value(db_key, db, default=None)
+            if value:
+                return value
     except Exception as e:
-        logger.warning(f"Failed to get ElevenLabs API key from database: {e}")
+        logger.warning(f"Failed to get setting '{db_key}' from database: {e}")
 
-    # Fallback to .env
-    return config.get_env("XI_API_KEY", "")
+    return config.get_env(env_key, env_default)
+
+
+def get_elevenlabs_api_key_global() -> str:
+    """Get ElevenLabs API key from database with .env fallback."""
+    return _get_global_setting("XI_API_KEY", "XI_API_KEY")
 
 
 def get_elevenlabs_voice_id_global() -> str:
-    """
-    Get ElevenLabs default voice ID from database with .env fallback.
-
-    The Settings UI saves this as 'XI_VOICE_ID' in the GlobalSetting table.
-
-    Returns:
-        ElevenLabs voice ID string, or empty string if not configured.
-    """
-    from src.db.database import SessionLocal
-    from src.config import config
-
-    # Try database first (primary source - set via Settings UI)
-    try:
-        with SessionLocal() as db:
-            voice_id = settings_service.get_setting_value("XI_VOICE_ID", db, default=None)
-            if voice_id:
-                return voice_id
-    except Exception as e:
-        logger.warning(f"Failed to get ElevenLabs voice ID from database: {e}")
-
-    # Fallback to .env
-    return config.get_env("XI_VOICE_ID", "")
+    """Get ElevenLabs default voice ID from database with .env fallback."""
+    return _get_global_setting("XI_VOICE_ID", "XI_VOICE_ID")

--- a/src/services/tts_service.py
+++ b/src/services/tts_service.py
@@ -8,7 +8,6 @@ Used by both the REST API endpoint and MCP talk() tool.
 import base64
 import io
 import logging
-import os
 from typing import Optional
 
 import httpx

--- a/src/services/tts_service.py
+++ b/src/services/tts_service.py
@@ -59,12 +59,14 @@ async def generate_tts_audio(
         TTSConfigError: If XI_API_KEY is not set.
         TTSError: If ElevenLabs API call fails.
     """
-    api_key = os.getenv("XI_API_KEY")
+    from src.services.settings_service import get_elevenlabs_api_key_global, get_elevenlabs_voice_id_global
+
+    api_key = get_elevenlabs_api_key_global()
     if not api_key:
-        raise TTSConfigError("ElevenLabs API key not found. Set XI_API_KEY environment variable.")
+        raise TTSConfigError("ElevenLabs API key not found. Set it via Settings UI or XI_API_KEY environment variable.")
 
     if voice_id is None:
-        voice_id = os.getenv("XI_VOICE_ID", DEFAULT_VOICE_ID)
+        voice_id = get_elevenlabs_voice_id_global() or DEFAULT_VOICE_ID
 
     _validate_path_segment(voice_id, "voice_id")
     url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"


### PR DESCRIPTION
## Summary
- TTS service now reads `XI_API_KEY` and `XI_VOICE_ID` from GlobalSetting database first, with env var fallback
- Adds `get_elevenlabs_api_key_global()` and `get_elevenlabs_voice_id_global()` to settings_service following the same pattern as `get_omni_api_key_global()`
- Adds Voice ID field to the Audio Generation settings UI

## Problem
The Settings UI had an editable "ElevenLabs API Key" field that saved to the GlobalSetting table, but `tts_service.py` only checked `os.getenv("XI_API_KEY")` — making the UI field non-functional (always returned 503).

## Test plan
- [ ] Set XI_API_KEY via Settings UI and verify TTS endpoint works without env var
- [ ] Verify env var fallback still works when no DB setting exists
- [ ] Verify Voice ID field appears in Audio Generation settings