### PR TITLE
fix: use sendWhatsAppAudio for native voice notes

### DIFF
--- a/resources/ui/src/components/settings/MediaProcessingSettings.tsx
+++ b/resources/ui/src/components/settings/MediaProcessingSettings.tsx
@@ -8,7 +8,19 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { api } from '@/lib';
-import { Eye, EyeOff, Save, Loader2, CheckCircle2, XCircle, Image, Mic, Sparkles, Volume2, AudioLines } from 'lucide-react';
+import {
+  Eye,
+  EyeOff,
+  Save,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Image,
+  Mic,
+  Sparkles,
+  Volume2,
+  AudioLines,
+} from 'lucide-react';
 
 interface SettingFieldProps {
   label: string;
@@ -20,7 +32,15 @@ interface SettingFieldProps {
   isSecret?: boolean;
 }
 
-function SettingField({ label, description, settingKey, currentValue, icon, placeholder, isSecret = false }: SettingFieldProps) {
+function SettingField({
+  label,
+  description,
+  settingKey,
+  currentValue,
+  icon,
+  placeholder,
+  isSecret = false,
+}: SettingFieldProps) {
   const queryClient = useQueryClient();
   const [value, setValue] = useState('');
   const [showValue, setShowValue] = useState(false);
@@ -52,9 +72,8 @@ function SettingField({ label, description, settingKey, currentValue, icon, plac
     setValue('');
   };
 
-  const displayValue = isSecret && currentValue
-    ? `${currentValue.substring(0, 8)}...${currentValue.slice(-4)}`
-    : currentValue;
+  const displayValue =
+    isSecret && currentValue ? `${currentValue.substring(0, 8)}...${currentValue.slice(-4)}` : currentValue;
 
   return (
     <div className="p-4 bg-muted rounded-lg border border-border space-y-3">

--- a/src/services/tts_service.py
+++ b/src/services/tts_service.py
@@ -202,19 +202,16 @@ async def send_tts_voice_note(
             except Exception as e:
                 logger.warning(f"Failed to send recording presence: {e}")
 
-        # 4. Send voice note via Evolution API
+        # 4. Send voice note via Evolution API (dedicated audio endpoint)
         audio_base64 = base64.b64encode(ogg_bytes).decode("utf-8")
         payload = {
             "number": recipient,
-            "mediatype": "audio",
-            "media": audio_base64,
-            "mimetype": "audio/ogg; codecs=opus",
-            "ptt": True,
+            "audio": audio_base64,
         }
 
         try:
             response = await client.post(
-                f"{evolution_url}/message/sendMedia/{instance_name}",
+                f"{evolution_url}/message/sendWhatsAppAudio/{instance_name}",
                 headers={"apikey": evolution_key, "Content-Type": "application/json"},
                 json=payload,
             )

--- a/tests/test_tts_service.py
+++ b/tests/test_tts_service.py
@@ -238,7 +238,7 @@ class TestSendTTSVoiceNote:
         # Verify presence was sent before the media
         assert len(post_calls) == 2
         assert "sendPresence" in post_calls[0]
-        assert "sendMedia" in post_calls[1]
+        assert "sendWhatsAppAudio" in post_calls[1]
 
     @pytest.mark.asyncio
     async def test_dynamic_presence_delay_matches_audio_duration(self):
@@ -419,9 +419,9 @@ class TestSendTTSVoiceNote:
                     )
 
         assert result["success"] is True
-        # Only sendMedia should have been called, no sendPresence
+        # Only sendWhatsAppAudio should have been called, no sendPresence
         assert len(post_urls) == 1
-        assert "sendMedia" in post_urls[0]
+        assert "sendWhatsAppAudio" in post_urls[0]
 
 
 # ===== Integration Tests: REST API endpoint =====


### PR DESCRIPTION
## Summary
- Switch TTS from generic `sendMedia` to dedicated `sendWhatsAppAudio` Evolution API endpoint
- Audio now arrives as native WhatsApp voice note (PTT bubble) instead of audio file attachment
- Tested and confirmed working on real device

## Test plan
- [x] Send TTS via `/api/v1/instance/{name}/send-tts` endpoint
- [x] Verify audio appears as native voice note on WhatsApp
- [x] All 28 TTS tests passing